### PR TITLE
44-cambio-de-gravedad-solo-mientras-esta-caminando

### DIFF
--- a/server/player.go
+++ b/server/player.go
@@ -22,7 +22,9 @@ func (player *Player) SetSpeed(x, y float64) {
 }
 
 func (player *Player) InvertGravity() {
-	player.HasGravityInverted = !player.HasGravityInverted
+	if player.IsWalking {
+		player.HasGravityInverted = !player.HasGravityInverted
 
-	player.SetSpeed(player.Speed.X, -player.Speed.Y)
+		player.SetSpeed(player.Speed.X, -player.Speed.Y)
+	}
 }


### PR DESCRIPTION
closes #44 

Agregar la condicion que el player este caminando para que se pueda realizar el cambio de gravedad. Caso contrario, el envio del comando de cambio de gravedad no tiene ningun efecto.