### PR TITLE
65 - Hacer que el personaje termine la carrera solo al cruzar la meta entera

### DIFF
--- a/server/world.go
+++ b/server/world.go
@@ -18,6 +18,7 @@ const (
 	playerSpeedX     float64 = float64(60) / TicksPerSecond
 	playerSpeedY             = float64(90) / TicksPerSecond
 	cameraLimitWidth         = cellSize
+	raceFinishWidth          = 50
 )
 
 type World struct {
@@ -78,7 +79,8 @@ func (world *World) Init(gameMap Map) {
 	// Add race finish
 	world.space.Add(
 		resolv.NewObject(
-			float64(gameMap.RaceFinish.X), float64(gameMap.RaceFinish.Y), cellSize, float64(gameMap.RaceFinish.Height),
+			float64(gameMap.RaceFinish.X+raceFinishWidth+playerWidth), // add raceFinishWidth+playerWidth to the x position so the collision in when the player cross the race finish completely
+			float64(gameMap.RaceFinish.Y), cellSize, float64(gameMap.RaceFinish.Height),
 			raceFinishTag,
 		),
 	)


### PR DESCRIPTION
closes #65 

Mover el objeto que representa la meta en mundo el ancho de la meta y el ancho del jugador unidades mas a la derecha de forma que la colision entre el jugador y este objeto sea cuando el jugador alla cruzado completamente la meta. 

Se prueba de forma local moviendo temporalmente la meta la posicion 500 en el mapa1.json, y se verifica que se considera que el jugador paso la meta solo al pasar la meta por completo:
![Screenshot 2024-11-02 at 8 21 58 PM](https://github.com/user-attachments/assets/c723b283-378a-4466-8b24-7c082f9735ab)
