### PR TITLE
59 enviar inicioJuego a todos los jugadores en respuesta a iniciarjuego

### DIFF
--- a/server/character.go
+++ b/server/character.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/solarlune/resolv"
+)
+
+type Character struct {
+	Object *resolv.Object
+	Speed  resolv.Vector
+
+	HasGravityInverted bool
+	IsWalking          bool
+	IsDead             bool
+}
+
+func (character *Character) SetSpeed(x, y float64) {
+	character.Speed.X = x
+	character.Speed.Y = y
+}
+
+func (character *Character) InvertGravity() {
+	if character.IsWalking {
+		character.HasGravityInverted = !character.HasGravityInverted
+
+		character.SetSpeed(character.Speed.X, -character.Speed.Y)
+	}
+}

--- a/server/client.go
+++ b/server/client.go
@@ -19,7 +19,7 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 		// TODO: mutex for each player, not only for the list
 		playersMutex.Lock()
 		// players[newClient.Id()].InvertGravity()
-		(*players)[0].InvertGravity()
+		(*players)[0].Character.InvertGravity()
 		playersMutex.Unlock()
 	})
 	if err != nil {

--- a/server/client.go
+++ b/server/client.go
@@ -49,12 +49,14 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 
 		gameStarted.Store(true)
 
+		playersMutex.Lock()
 		for _, player := range *players {
 			err = player.SendInicioJuego()
 			if err != nil {
 				log.Println("failed to send inicioJuego", "err", err)
 			}
 		}
+		playersMutex.Unlock()
 
 		gameStart <- true
 	})

--- a/server/client.go
+++ b/server/client.go
@@ -34,6 +34,8 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 	if err != nil {
 		log.Println("failed to register on changeGravity message", "err", err)
 		newClient.Disconnect(true)
+
+		return
 	}
 
 	err = newClient.On("iniciarJuego", func(datas ...any) {
@@ -59,6 +61,8 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 	if err != nil {
 		log.Println("failed to register on iniciarJuego message", "err", err)
 		newClient.Disconnect(true)
+
+		return
 	}
 
 	err = newClient.On("unirSala", func(datas ...any) {
@@ -74,6 +78,8 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 	if err != nil {
 		log.Println("failed to register on unirSala message", "err", err)
 		newClient.Disconnect(true)
+
+		return
 	}
 
 	err = newClient.On("initSala", func(datas ...any) {
@@ -89,10 +95,11 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 			log.Println("initSala event received but no map name provided")
 		}
 	})
-
 	if err != nil {
-		log.Println("Fallo iniciando la sala", "err", err)
+		log.Println("failed to register on initSala message", "err", err)
 		newClient.Disconnect(true)
+
+		return
 	}
 
 	err = newClient.On("disconnect", func(...any) {
@@ -105,6 +112,8 @@ func manageClientConnection(clients []any, playersMutex *sync.Mutex, players *[]
 	if err != nil {
 		log.Println("failed to register on disconnect message", "err", err)
 		newClient.Disconnect(true)
+
+		return
 	}
 
 	newPlayer := &Player{

--- a/server/game.go
+++ b/server/game.go
@@ -33,7 +33,7 @@ func (playerInfo PlayerInfo) ToMap() map[string]any {
 }
 
 func initGame(world *World) {
-	for _, player := range *world.Players {
+	for _, player := range world.Players {
 		err := player.Socket.Emit("juegoIniciado")
 		if err != nil {
 			log.Println("failed to send juegoIniciado", "err", err)
@@ -45,7 +45,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 	ticker := time.NewTicker(time.Second / TicksPerSecond)
 	quit := make(chan struct{})
 
-	amountOfPlayers := len(*world.Players)
+	amountOfPlayers := len(world.Players)
 
 	playersThatFinished := make([]int, 0, amountOfPlayers)
 	playersThatDied := make([]int, 0, amountOfPlayers)
@@ -70,7 +70,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 
 				raceResult := append(playersThatFinished, playersThatDied...)
 
-				for _, player := range *world.Players {
+				for _, player := range world.Players {
 					err := player.Socket.Emit("carreraTerminada", raceResult)
 					if err != nil {
 						log.Println("failed to send carreraTerminada", "err", err)
@@ -80,7 +80,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 				ticker.Stop()
 				return
 			} else {
-				for _, player := range *world.Players {
+				for _, player := range world.Players {
 					posX := player.Object.Position.X
 					posY := player.Object.Position.Y
 					hasGravityInverted := player.HasGravityInverted
@@ -112,7 +112,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 					playersPositionsProtocol = append(playersPositionsProtocol, playersPosition.ToMap())
 				}
 
-				for _, player := range *world.Players {
+				for _, player := range world.Players {
 					err := player.Socket.Emit("tick", playersPositionsProtocol, cameraX)
 					if err != nil {
 						log.Println("failed to send tick", "err", err)

--- a/server/game.go
+++ b/server/game.go
@@ -81,11 +81,11 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 				return
 			} else {
 				for _, player := range world.Players {
-					posX := player.Object.Position.X
-					posY := player.Object.Position.Y
-					hasGravityInverted := player.HasGravityInverted
-					isWalking := player.IsWalking
-					isDead := player.IsDead
+					posX := player.Character.Object.Position.X
+					posY := player.Character.Object.Position.Y
+					hasGravityInverted := player.Character.HasGravityInverted
+					isWalking := player.Character.IsWalking
+					isDead := player.Character.IsDead
 
 					point := Point{
 						X: int(posX),
@@ -113,7 +113,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 				}
 
 				for _, player := range world.Players {
-					err := player.Socket.Emit("tick", playersPositionsProtocol, cameraX)
+					err := player.SendTick(playersPositionsProtocol, cameraX)
 					if err != nil {
 						log.Println("failed to send tick", "err", err)
 					}

--- a/server/main.go
+++ b/server/main.go
@@ -48,7 +48,7 @@ func main() {
 	<-gameStart
 
 	log.Println("Creating world")
-	world := NewWorld(gameMap, players)
+	world := NewWorld(gameMap, *players)
 
 	gameLoop(world, playersMutex)
 	for {

--- a/server/main.go
+++ b/server/main.go
@@ -23,18 +23,11 @@ func main() {
 	// players := map[socket.SocketId]Player{}
 	players := &[]*Player{}
 
-	gameStarted := false
 	gameStart := make(chan bool)
-	expectedPlayers := 2
 
 	err := io.On("connection", func(clients ...any) {
 		// TODO manejar conexiones de mas
 		manageClientConnection(clients, playersMutex, players, gameStart)
-
-		if !gameStarted && len((*players)) >= expectedPlayers {
-			gameStarted = true
-			gameStart <- gameStarted
-		}
 	})
 	if err != nil {
 		log.Fatalln("Error setting sockert.io on connection", "err", err)

--- a/server/player.go
+++ b/server/player.go
@@ -12,3 +12,7 @@ type Player struct {
 func (player *Player) SendTick(playersPositions []any, cameraX int) error {
 	return player.Socket.Emit("tick", playersPositions, cameraX)
 }
+
+func (player *Player) SendInicioJuego() error {
+	return player.Socket.Emit("inicioJuego")
+}

--- a/server/player.go
+++ b/server/player.go
@@ -1,30 +1,14 @@
 package main
 
 import (
-	"github.com/solarlune/resolv"
 	"github.com/zishang520/socket.io/v2/socket"
 )
 
 type Player struct {
-	Socket *socket.Socket
-
-	Object *resolv.Object
-	Speed  resolv.Vector
-
-	HasGravityInverted bool
-	IsWalking          bool
-	IsDead             bool
+	Socket    *socket.Socket
+	Character Character
 }
 
-func (player *Player) SetSpeed(x, y float64) {
-	player.Speed.X = x
-	player.Speed.Y = y
-}
-
-func (player *Player) InvertGravity() {
-	if player.IsWalking {
-		player.HasGravityInverted = !player.HasGravityInverted
-
-		player.SetSpeed(player.Speed.X, -player.Speed.Y)
-	}
+func (player *Player) SendTick(playersPositions []any, cameraX int) error {
+	return player.Socket.Emit("tick", playersPositions, cameraX)
 }

--- a/server/world.go
+++ b/server/world.go
@@ -25,12 +25,12 @@ type World struct {
 
 	// playersMutex *sync.Mutex
 	// players := map[socket.SocketId]Player{}
-	Players *[]*Player
+	Players []*Player
 
 	cameraLimit *resolv.Object
 }
 
-func NewWorld(gameMap Map, players *[]*Player) *World {
+func NewWorld(gameMap Map, players []*Player) *World {
 	w := &World{
 		Players: players,
 	}
@@ -98,7 +98,7 @@ func (world *World) Init(gameMap Map) {
 	}
 
 	// Create Players' objects and add it to the world's Space.
-	for _, player := range *world.Players {
+	for _, player := range world.Players {
 		// TODO mover posicion inicial de aca uno
 		playerObject := resolv.NewObject(
 			float64(gameMap.PlayersStart.X), float64(gameMap.PlayersStart.Y), playerWidth, playerHeight,
@@ -118,7 +118,7 @@ func (world *World) Init(gameMap Map) {
 //   - finishedPlayers: list of the players that finished the race this tick
 //   - diedPlayers: list of the players that died this tick
 func (world *World) Update() (finishedPlayers []int, diedPlayers []int) {
-	for i, player := range *world.Players {
+	for i, player := range world.Players {
 		if !player.IsDead {
 			// TODO aca tener cuidado con colisiones entre los mismos players, calcular antes de avanzar
 			world.updatePlayerPosition(player)

--- a/server/world.go
+++ b/server/world.go
@@ -105,8 +105,8 @@ func (world *World) Init(gameMap Map) {
 			playerTag,
 		)
 
-		player.Object = playerObject
-		player.SetSpeed(playerSpeedX, -playerSpeedY)
+		player.Character.Object = playerObject
+		player.Character.SetSpeed(playerSpeedX, -playerSpeedY)
 
 		world.space.Add(playerObject)
 	}
@@ -119,7 +119,7 @@ func (world *World) Init(gameMap Map) {
 //   - diedPlayers: list of the players that died this tick
 func (world *World) Update() (finishedPlayers []int, diedPlayers []int) {
 	for i, player := range world.Players {
-		if !player.IsDead {
+		if !player.Character.IsDead {
 			// TODO aca tener cuidado con colisiones entre los mismos players, calcular antes de avanzar
 			world.updatePlayerPosition(player)
 
@@ -141,10 +141,10 @@ func (world *World) Update() (finishedPlayers []int, diedPlayers []int) {
 
 // checkIfPlayerHasDied updates player's IsDead if the player touched a world limit
 func (world *World) checkIfPlayerHasDied(player *Player) bool {
-	if collision := player.Object.Check(0, 0, worldLimitTag); collision != nil {
+	if collision := player.Character.Object.Check(0, 0, worldLimitTag); collision != nil {
 		log.Println("Player is dead")
 
-		player.IsDead = true
+		player.Character.IsDead = true
 
 		return true
 	}
@@ -154,10 +154,10 @@ func (world *World) checkIfPlayerHasDied(player *Player) bool {
 
 // checkIfPlayerFinishedRace updates player's IsDead if the player touched the race finish
 func (world *World) checkIfPlayerFinishedRace(player *Player) bool {
-	if collision := player.Object.Check(0, 0, raceFinishTag); collision != nil {
+	if collision := player.Character.Object.Check(0, 0, raceFinishTag); collision != nil {
 		log.Println("Player finished race")
 
-		player.IsDead = true
+		player.Character.IsDead = true
 
 		return true
 	}
@@ -175,21 +175,21 @@ func (world *World) updatePlayerPosition(player *Player) {
 
 	// dx is the horizontal delta movement variable (which is the Player's horizontal speed). If we come into contact with something, then it will
 	// be that movement instead.
-	dx := player.Speed.X
+	dx := player.Character.Speed.X
 
-	log.Println(player.Object.Position)
+	log.Println(player.Character.Object.Position)
 
 	// Moving horizontally is done fairly simply;
 	// we just check to see if something solid is in front of us. If so, we move into contact with it
 	// and stop horizontal movement speed. If not, then we can just move forward.
 
-	if collision := player.Object.Check(dx, 0, solidTag); collision != nil {
+	if collision := player.Character.Object.Check(dx, 0, solidTag); collision != nil {
 		log.Println("Colision en x")
 		dx = collision.ContactWithCell(collision.Cells[0]).X
 	}
 
 	// Then we just apply the horizontal movement to the Player's Object. Easy-peasy.
-	player.Object.Position.X += dx
+	player.Character.Object.Position.X += dx
 
 	// Now for the vertical movement; it's the most complicated because we can land on different types of objects and need
 	// to treat them all differently, but overall, it's not bad.
@@ -198,29 +198,29 @@ func (world *World) updatePlayerPosition(player *Player) {
 	// if we come into contact with
 	// something, this will be changed to move to contact instead.
 
-	dy := player.Speed.Y
+	dy := player.Character.Speed.Y
 
 	// We want to be sure to lock vertical movement to a maximum of the size of the Cells within the Space
 	// so we don't miss any collisions by tunneling through.
 
 	dy = math.Max(math.Min(dy, cellSize), -cellSize)
 
-	player.IsWalking = false
+	player.Character.IsWalking = false
 
 	// We check for any solid / stand-able objects. In actuality, there aren't any other Objects
 	// with other tags in this Space, so we don't -have- to specify any tags, but it's good to be specific for clarity in this example.
-	if collision := player.Object.Check(0, dy, solidTag); collision != nil {
+	if collision := player.Character.Object.Check(0, dy, solidTag); collision != nil {
 		log.Println("Colision en y")
 
 		dy = collision.ContactWithCell(collision.Cells[0]).Y
 
-		player.IsWalking = true
+		player.Character.IsWalking = true
 	}
 
 	// Move the object on dy.
-	player.Object.Position.Y += dy
+	player.Character.Object.Position.Y += dy
 
-	player.Object.Update() // Update the player's position in the space.
+	player.Character.Object.Update() // Update the player's position in the space.
 }
 
 // UpdateCameraLimitPosition updates the position of the camera limit that is used in the world


### PR DESCRIPTION
closes #59 

- Refactorizacion: separar la entidad player y character dado que el socket no es necesario en el mundo
- enviar el mensaje inicioJuego a todos los jugadores conectados cuando se recibe el mensaje iniciarJuego (el ticket inicialmente decia que el mensaje debia ser juegoIniciado, pero se mantiene iniciarJuego dado que es el mensaje que el cliente esta preparado para recibir)
- Mejorar el manejo de errores para evitar considerar conectados a jugadores cuya configuracion de mensaje falle