### PR TITLE
61 acomodar jugadores en posicion inicial + 56 Enviar en cada tick la posicion de todos los personajes

### DIFF
--- a/server/character.go
+++ b/server/character.go
@@ -13,6 +13,12 @@ type Character struct {
 	IsDead             bool
 }
 
+func NewCharacter(object *resolv.Object) *Character {
+	return &Character{
+		Object: object,
+	}
+}
+
 func (character *Character) SetSpeed(x, y float64) {
 	character.Speed.X = x
 	character.Speed.Y = y

--- a/server/client.go
+++ b/server/client.go
@@ -20,6 +20,13 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 
 	log.Println("connection established. new client: ", newClientID)
 
+	if gameStarted.Load() {
+		log.Println("connection established received when the game has already begun, rejecting client")
+		newClient.Disconnect(true)
+
+		return
+	}
+
 	err := newClient.On("changeGravity", func(datas ...any) {
 		log.Println("changeGravity event received")
 

--- a/server/client.go
+++ b/server/client.go
@@ -2,17 +2,11 @@ package main
 
 import (
 	"log"
-	"sync/atomic"
 
 	"github.com/zishang520/socket.io/v2/socket"
 )
 
-var (
-	gameStarted atomic.Bool
-	room        = NewRoom()
-)
-
-const mapName = "mapa1"
+var room = NewRoom("mapa1")
 
 func manageClientConnection(clients []any, gameStart chan *Room) {
 	newClient := clients[0].(*socket.Socket)
@@ -20,17 +14,19 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 
 	log.Println("connection established. new client: ", newClientID)
 
-	if gameStarted.Load() {
+	if room.GameStarted.Load() {
 		log.Println("connection established received when the game has already begun, rejecting client")
 		newClient.Disconnect(true)
 
 		return
 	}
 
+	newPlayer := NewPlayer(newClient)
+
 	err := newClient.On("changeGravity", func(datas ...any) {
 		log.Println("changeGravity event received")
 
-		if !gameStarted.Load() {
+		if !room.GameStarted.Load() {
 			log.Println("changeGravity event received when the game has not yet started, ignoring message")
 
 			return
@@ -38,8 +34,7 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 
 		// TODO: mutex for each player, not only for the list
 		room.Mutex.Lock()
-		// players[newClient.Id()].InvertGravity()
-		room.Players[0].Character.InvertGravity()
+		newPlayer.Character.InvertGravity()
 		room.Mutex.Unlock()
 	})
 	if err != nil {
@@ -52,22 +47,7 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 	err = newClient.On("iniciarJuego", func(datas ...any) {
 		log.Println("iniciarJuego event received")
 
-		if gameStarted.Load() {
-			log.Println("iniciarJuego event received when the game has already begun, ignoring message")
-
-			return
-		}
-
-		gameStarted.Store(true)
-
-		room.Mutex.Lock()
-		for _, player := range room.Players {
-			err = player.SendInicioJuego()
-			if err != nil {
-				log.Println("failed to send inicioJuego", "err", err)
-			}
-		}
-		room.Mutex.Unlock()
+		room.StartGame()
 
 		gameStart <- room
 	})
@@ -119,10 +99,8 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 
 	err = newClient.On("disconnect", func(...any) {
 		log.Println("client disconnected", newClient.Id())
-		// delete(players, newClientID)
-		room.Mutex.Lock()
-		room.Players = []*Player{}
-		room.Mutex.Unlock()
+
+		room.RemovePlayer(newPlayer)
 	})
 	if err != nil {
 		log.Println("failed to register on disconnect message", "err", err)
@@ -131,25 +109,5 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 		return
 	}
 
-	newPlayer := &Player{
-		Socket: newClient,
-	}
-
-	room.Mutex.Lock()
 	room.AddPlayer(newPlayer)
-
-	playersInfo := make([]map[string]any, 0, len(room.Players))
-
-	for _, player := range room.Players {
-		playersInfo = append(playersInfo, player.ToInformacionSalaInfo())
-	}
-
-	for _, player := range room.Players {
-		err := player.SendInformacionSala(room.ID, mapName, playersInfo)
-		if err != nil {
-			log.Println("failed to send informacionSala", "err", err)
-		}
-	}
-
-	room.Mutex.Unlock()
 }

--- a/server/game.go
+++ b/server/game.go
@@ -62,7 +62,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 				raceResult := append(playersThatFinished, playersThatDied...)
 
 				for _, player := range world.Players {
-					err := player.Socket.Emit("carreraTerminada", raceResult)
+					err := player.SendCarreraTerminada(raceResult)
 					if err != nil {
 						log.Println("failed to send carreraTerminada", "err", err)
 					}
@@ -84,7 +84,7 @@ func gameLoop(world *World, playersMutex *sync.Mutex) {
 					}.FromServerToClient(mapHeight, playerWidth, playerHeight)
 
 					playersPositions = append(playersPositions, PlayerInfo{
-						playerNumber:       1, // TODO send more players
+						playerNumber:       player.ID,
 						posX:               point.X,
 						posY:               point.Y,
 						hasGravityInverted: hasGravityInverted,

--- a/server/go.mod
+++ b/server/go.mod
@@ -3,9 +3,10 @@ module github.com/luchowaldman/elpibegravedad/server
 go 1.23.1
 
 require (
+	github.com/elliotchance/pie/v2 v2.9.0
+	github.com/google/uuid v1.6.0
 	github.com/solarlune/resolv v0.7.0
 	github.com/zishang520/socket.io/v2 v2.3.0
-	github.com/google/uuid v1.6.0
 )
 
 require (

--- a/server/go.sum
+++ b/server/go.sum
@@ -3,6 +3,8 @@ github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer5
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/elliotchance/pie/v2 v2.9.0 h1:BkEhh8b/avGCSpXpABSjNuytxlI/S2snkjT3vtVORjw=
+github.com/elliotchance/pie/v2 v2.9.0/go.mod h1:18t0dgGFH006g4eVdDtWfgFZPQEgl10IoEO8YWEq3Og=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=

--- a/server/main.go
+++ b/server/main.go
@@ -21,11 +21,10 @@ func main() {
 	gameStart := make(chan *Room)
 
 	err := io.On("connection", func(clients ...any) {
-		// TODO manejar conexiones de mas
 		manageClientConnection(clients, gameStart)
 	})
 	if err != nil {
-		log.Fatalln("Error setting sockert.io on connection", "err", err)
+		log.Fatalln("Error setting socket.io on connection", "err", err)
 	}
 
 	go func() {

--- a/server/main.go
+++ b/server/main.go
@@ -37,7 +37,7 @@ func main() {
 	log.Println("Creating world")
 	world := NewWorld(gameMap, room.Players)
 
-	gameLoop(world, room.Mutex)
+	gameLoop(world, room)
 	for {
 		time.Sleep(5 * time.Second)
 	}

--- a/server/player.go
+++ b/server/player.go
@@ -9,7 +9,7 @@ type Player struct {
 	ID        int
 	Name      string
 	Socket    *socket.Socket
-	Character Character
+	Character *Character
 }
 
 func NewPlayer(socket *socket.Socket) *Player {

--- a/server/player.go
+++ b/server/player.go
@@ -6,25 +6,46 @@ import (
 )
 
 type Player struct {
+	ID        int
+	Name      string
 	Socket    *socket.Socket
 	Character Character
 }
 
+func NewPlayer(socket *socket.Socket) *Player {
+	return &Player{
+		Socket: socket,
+		Name:   "Franco",
+	}
+}
+
 func (player *Player) SendTick(playersPositions []any, cameraX int) error {
-	return player.Socket.Emit("tick", playersPositions, cameraX)
+	return player.emit("tick", playersPositions, cameraX)
 }
 
 func (player *Player) SendInicioJuego() error {
-	return player.Socket.Emit("inicioJuego")
+	return player.emit("inicioJuego")
 }
 
 func (player *Player) SendInformacionSala(roomUUID uuid.UUID, mapName string, players []map[string]any) error {
-	return player.Socket.Emit("informacionSala", roomUUID.String(), mapName, players)
+	return player.emit("informacionSala", roomUUID.String(), mapName, players)
 }
 
 func (player *Player) ToInformacionSalaInfo() map[string]any {
 	return map[string]any{
-		"numeroJugador": 1,
-		"nombre":        "Franco",
+		"numeroJugador": player.ID,
+		"nombre":        player.Name,
 	}
+}
+
+func (player *Player) SendCarreraTerminada(raceResult []int) error {
+	return player.emit("carreraTerminada", raceResult)
+}
+
+func (player *Player) emit(ev string, args ...any) error {
+	if player.Socket == nil {
+		return nil
+	}
+
+	return player.Socket.Emit(ev, args...)
 }

--- a/server/room.go
+++ b/server/room.go
@@ -1,28 +1,92 @@
 package main
 
 import (
+	"log"
 	"sync"
+	"sync/atomic"
 
+	"github.com/elliotchance/pie/v2"
 	"github.com/google/uuid"
 )
 
 type Room struct {
-	ID      uuid.UUID
-	Mutex   *sync.Mutex
-	Players []*Player
+	ID           uuid.UUID
+	Mutex        *sync.Mutex
+	Players      []*Player
+	GameStarted  atomic.Bool
+	MapName      string
+	NextPlayerID int
 }
 
-func NewRoom() *Room {
+func NewRoom(mapName string) *Room {
 	return &Room{
-		ID:    uuid.New(),
-		Mutex: &sync.Mutex{},
+		ID:           uuid.New(),
+		Mutex:        &sync.Mutex{},
+		MapName:      mapName,
+		NextPlayerID: 1,
 	}
 }
 
 func (room *Room) AddPlayer(newPlayer *Player) {
-	// players[newClientID] = Player{
-	// 	Socket: newClient,
-	// }
+	room.Mutex.Lock()
+
+	newPlayer.ID = room.NextPlayerID
+	room.NextPlayerID++
 
 	room.Players = append(room.Players, newPlayer)
+	room.sendInformacionSala()
+
+	room.Mutex.Unlock()
+}
+
+func (room *Room) RemovePlayer(oldPlayer *Player) {
+	room.Mutex.Lock()
+
+	// if the game didn't start yet, remove the player
+	if !room.GameStarted.Load() {
+		room.Players = pie.Filter(room.Players, func(player *Player) bool {
+			return player != oldPlayer
+		})
+
+		room.sendInformacionSala()
+	}
+
+	oldPlayer.Socket = nil
+	room.Mutex.Unlock()
+}
+
+func (room *Room) StartGame() {
+	room.Mutex.Lock()
+
+	if room.GameStarted.Load() {
+		log.Println("iniciarJuego event received when the game has already begun, ignoring message")
+
+		return
+	}
+
+	room.GameStarted.Store(true)
+
+	for _, player := range room.Players {
+		err := player.SendInicioJuego()
+		if err != nil {
+			log.Println("failed to send inicioJuego", "err", err)
+		}
+	}
+
+	room.Mutex.Unlock()
+}
+
+func (room *Room) sendInformacionSala() {
+	playersInfo := make([]map[string]any, 0, len(room.Players))
+
+	for _, player := range room.Players {
+		playersInfo = append(playersInfo, player.ToInformacionSalaInfo())
+	}
+
+	for _, player := range room.Players {
+		err := player.SendInformacionSala(room.ID, room.MapName, playersInfo)
+		if err != nil {
+			log.Println("failed to send informacionSala", "err", err)
+		}
+	}
 }

--- a/server/world.go
+++ b/server/world.go
@@ -8,17 +8,18 @@ import (
 )
 
 const (
-	cellSize                 = 5
-	solidTag                 = "solid"
-	worldLimitTag            = "worldLimit"
-	raceFinishTag            = "raceFinish"
-	playerTag                = "player"
-	playerHeight             = 50
-	playerWidth              = 35
-	playerSpeedX     float64 = float64(60) / TicksPerSecond
-	playerSpeedY             = float64(90) / TicksPerSecond
-	cameraLimitWidth         = cellSize
-	raceFinishWidth          = 50
+	cellSize                              = 5
+	solidTag                              = "solid"
+	worldLimitTag                         = "worldLimit"
+	raceFinishTag                         = "raceFinish"
+	playerTag                             = "player"
+	playerHeight                          = 50
+	playerWidth                           = 35
+	playerSpeedX                  float64 = float64(60) / TicksPerSecond
+	playerSpeedY                          = float64(90) / TicksPerSecond
+	cameraLimitWidth                      = cellSize
+	raceFinishWidth                       = 50
+	playerInitialPositionDistance         = 20
 )
 
 type World struct {
@@ -100,10 +101,12 @@ func (world *World) Init(gameMap Map) {
 	}
 
 	// Create Players' objects and add it to the world's Space.
-	for _, player := range world.Players {
-		// TODO mover posicion inicial de aca uno
+	playerInitialX := float64(gameMap.PlayersStart.X)
+	playerInitialY := float64(gameMap.PlayersStart.Y)
+
+	for i, player := range world.Players {
 		playerObject := resolv.NewObject(
-			float64(gameMap.PlayersStart.X), float64(gameMap.PlayersStart.Y), playerWidth, playerHeight,
+			playerInitialX, playerInitialY, playerWidth, playerHeight,
 			playerTag,
 		)
 
@@ -111,6 +114,13 @@ func (world *World) Init(gameMap Map) {
 		player.Character.SetSpeed(playerSpeedX, -playerSpeedY)
 
 		world.space.Add(playerObject)
+
+		if i%2 == 0 {
+			playerInitialX = playerInitialX - playerWidth - playerInitialPositionDistance
+			playerInitialY = playerInitialY - playerHeight - playerInitialPositionDistance
+		} else {
+			playerInitialY = playerInitialY + playerHeight + playerInitialPositionDistance
+		}
 	}
 }
 

--- a/server/world.go
+++ b/server/world.go
@@ -130,7 +130,7 @@ func (world *World) Init(gameMap Map) {
 //   - finishedPlayers: list of the players that finished the race this tick
 //   - diedPlayers: list of the players that died this tick
 func (world *World) Update() (finishedPlayers []int, diedPlayers []int) {
-	for i, player := range world.Players {
+	for _, player := range world.Players {
 		if !player.Character.IsDead {
 			// TODO aca tener cuidado con colisiones entre los mismos players, calcular antes de avanzar
 			world.updatePlayerPosition(player)
@@ -138,11 +138,11 @@ func (world *World) Update() (finishedPlayers []int, diedPlayers []int) {
 			playerFinished := world.checkIfPlayerFinishedRace(player)
 
 			if playerFinished {
-				finishedPlayers = append(finishedPlayers, i+1)
+				finishedPlayers = append(finishedPlayers, player.ID)
 			} else {
 				playerDied := world.checkIfPlayerHasDied(player)
 				if playerDied {
-					diedPlayers = append(diedPlayers, i+1)
+					diedPlayers = append(diedPlayers, player.ID)
 				}
 			}
 		}

--- a/server/world.go
+++ b/server/world.go
@@ -8,40 +8,35 @@ import (
 )
 
 const (
-	cellSize                              = 5
-	solidTag                              = "solid"
-	worldLimitTag                         = "worldLimit"
-	raceFinishTag                         = "raceFinish"
-	playerTag                             = "player"
-	playerHeight                          = 50
-	playerWidth                           = 35
-	playerSpeedX                  float64 = float64(60) / TicksPerSecond
-	playerSpeedY                          = float64(90) / TicksPerSecond
-	cameraLimitWidth                      = cellSize
-	raceFinishWidth                       = 50
-	playerInitialPositionDistance         = 20
+	cellSize                                 = 5
+	solidTag                                 = "solid"
+	worldLimitTag                            = "worldLimit"
+	raceFinishTag                            = "raceFinish"
+	characterTag                             = "character"
+	characterHeight                          = 50
+	characterWidth                           = 35
+	characterSpeedX                  float64 = float64(60) / TicksPerSecond
+	characterSpeedY                  float64 = float64(90) / TicksPerSecond
+	cameraLimitWidth                         = cellSize
+	raceFinishWidth                          = 50
+	characterInitialPositionDistance         = 20
 )
 
 type World struct {
 	space *resolv.Space
 
-	// playersMutex *sync.Mutex
-	// players := map[socket.SocketId]Player{}
-	Players []*Player
-
 	cameraLimit *resolv.Object
 }
 
 func NewWorld(gameMap Map, players []*Player) *World {
-	w := &World{
-		Players: players,
-	}
-	w.Init(gameMap)
+	w := &World{}
+
+	w.Init(gameMap, players)
 
 	return w
 }
 
-func (world *World) Init(gameMap Map) {
+func (world *World) Init(gameMap Map, players []*Player) {
 	// Initialize the world.
 
 	log.Println("starting world with dimensions: ", gameMap.Width, gameMap.Height)
@@ -80,7 +75,7 @@ func (world *World) Init(gameMap Map) {
 	// Add race finish
 	world.space.Add(
 		resolv.NewObject(
-			float64(gameMap.RaceFinish.X+raceFinishWidth+playerWidth), // add raceFinishWidth+playerWidth to the x position so the collision in when the player cross the race finish completely
+			float64(gameMap.RaceFinish.X+raceFinishWidth+characterWidth), // add raceFinishWidth+characterWidth to the x position so the collision in when the character cross the race finish completely
 			float64(gameMap.RaceFinish.Y), cellSize, float64(gameMap.RaceFinish.Height),
 			raceFinishTag,
 		),
@@ -100,63 +95,56 @@ func (world *World) Init(gameMap Map) {
 		)
 	}
 
-	// Create Players' objects and add it to the world's Space.
-	playerInitialX := float64(gameMap.PlayersStart.X)
-	playerInitialY := float64(gameMap.PlayersStart.Y)
+	// Create Characters' objects and add it to the world's Space.
+	characterInitialX := float64(gameMap.PlayersStart.X)
+	characterInitialY := float64(gameMap.PlayersStart.Y)
 
-	for i, player := range world.Players {
-		playerObject := resolv.NewObject(
-			playerInitialX, playerInitialY, playerWidth, playerHeight,
-			playerTag,
+	for i, player := range players {
+		characterObject := resolv.NewObject(
+			characterInitialX, characterInitialY, characterWidth, characterHeight,
+			characterTag,
 		)
 
-		player.Character.Object = playerObject
-		player.Character.SetSpeed(playerSpeedX, -playerSpeedY)
+		player.Character = NewCharacter(characterObject)
+		player.Character.SetSpeed(characterSpeedX, -characterSpeedY)
 
-		world.space.Add(playerObject)
+		world.space.Add(characterObject)
 
 		if i%2 == 0 {
-			playerInitialX = playerInitialX - playerWidth - playerInitialPositionDistance
-			playerInitialY = playerInitialY - playerHeight - playerInitialPositionDistance
+			characterInitialX = characterInitialX - characterWidth - characterInitialPositionDistance
+			characterInitialY = characterInitialY - characterHeight - characterInitialPositionDistance
 		} else {
-			playerInitialY = playerInitialY + playerHeight + playerInitialPositionDistance
+			characterInitialY = characterInitialY + characterHeight + characterInitialPositionDistance
 		}
 	}
 }
 
-// Update updates the world with the new position of each player
+// Update updates the world with the new position of the character
 //
 // Returns:
-//   - finishedPlayers: list of the players that finished the race this tick
-//   - diedPlayers: list of the players that died this tick
-func (world *World) Update() (finishedPlayers []int, diedPlayers []int) {
-	for _, player := range world.Players {
-		if !player.Character.IsDead {
-			// TODO aca tener cuidado con colisiones entre los mismos players, calcular antes de avanzar
-			world.updatePlayerPosition(player)
+//   - finished: true if the character finished the race this tick
+//   - died: true if the character died this tick
+func (world *World) Update(character *Character) (bool, bool) {
+	if !character.IsDead {
+		// TODO aca tener cuidado con colisiones entre los mismos players, calcular antes de avanzar
+		world.updateCharacterPosition(character)
 
-			playerFinished := world.checkIfPlayerFinishedRace(player)
-
-			if playerFinished {
-				finishedPlayers = append(finishedPlayers, player.ID)
-			} else {
-				playerDied := world.checkIfPlayerHasDied(player)
-				if playerDied {
-					diedPlayers = append(diedPlayers, player.ID)
-				}
-			}
+		if world.checkIfCharacterFinishedRace(character) {
+			return true, false
 		}
+
+		return false, world.checkIfCharacterHasDied(character)
 	}
 
-	return
+	return false, false
 }
 
-// checkIfPlayerHasDied updates player's IsDead if the player touched a world limit
-func (world *World) checkIfPlayerHasDied(player *Player) bool {
-	if collision := player.Character.Object.Check(0, 0, worldLimitTag); collision != nil {
-		log.Println("Player is dead")
+// checkIfCharacterHasDied updates character's IsDead if the character touched a world limit
+func (world *World) checkIfCharacterHasDied(character *Character) bool {
+	if collision := character.Object.Check(0, 0, worldLimitTag); collision != nil {
+		log.Println("Character is dead")
 
-		player.Character.IsDead = true
+		character.IsDead = true
 
 		return true
 	}
@@ -164,12 +152,12 @@ func (world *World) checkIfPlayerHasDied(player *Player) bool {
 	return false
 }
 
-// checkIfPlayerFinishedRace updates player's IsDead if the player touched the race finish
-func (world *World) checkIfPlayerFinishedRace(player *Player) bool {
-	if collision := player.Character.Object.Check(0, 0, raceFinishTag); collision != nil {
-		log.Println("Player finished race")
+// checkIfCharacterFinishedRace updates character's IsDead if the character touched the race finish
+func (world *World) checkIfCharacterFinishedRace(character *Character) bool {
+	if collision := character.Object.Check(0, 0, raceFinishTag); collision != nil {
+		log.Println("Character finished race")
 
-		player.Character.IsDead = true
+		character.IsDead = true
 
 		return true
 	}
@@ -177,31 +165,31 @@ func (world *World) checkIfPlayerFinishedRace(player *Player) bool {
 	return false
 }
 
-func (world *World) updatePlayerPosition(player *Player) {
-	// we update the Player's movement. This is the real bread-and-butter of this example, naturally.
+func (world *World) updateCharacterPosition(character *Character) {
+	// we update the Character's movement
 
 	// We handle horizontal movement separately from vertical movement. This is, conceptually, decomposing movement into two phases / axes.
 	// By decomposing movement in this manner, we can handle each case properly (i.e. stop movement horizontally separately from vertical movement, as
 	// necessary). More can be seen on this topic over on this blog post on higherorderfun.com:
 	// http://higherorderfun.com/blog/2012/05/20/the-guide-to-implementing-2d-platformers/
 
-	// dx is the horizontal delta movement variable (which is the Player's horizontal speed). If we come into contact with something, then it will
+	// dx is the horizontal delta movement variable (which is the Character's horizontal speed). If we come into contact with something, then it will
 	// be that movement instead.
-	dx := player.Character.Speed.X
+	dx := character.Speed.X
 
-	log.Println(player.Character.Object.Position)
+	log.Println(character.Object.Position)
 
 	// Moving horizontally is done fairly simply;
 	// we just check to see if something solid is in front of us. If so, we move into contact with it
 	// and stop horizontal movement speed. If not, then we can just move forward.
 
-	if collision := player.Character.Object.Check(dx, 0, solidTag); collision != nil {
+	if collision := character.Object.Check(dx, 0, solidTag); collision != nil {
 		log.Println("Colision en x")
 		dx = collision.ContactWithCell(collision.Cells[0]).X
 	}
 
-	// Then we just apply the horizontal movement to the Player's Object. Easy-peasy.
-	player.Character.Object.Position.X += dx
+	// Then we just apply the horizontal movement to the Character's Object. Easy-peasy.
+	character.Object.Position.X += dx
 
 	// Now for the vertical movement; it's the most complicated because we can land on different types of objects and need
 	// to treat them all differently, but overall, it's not bad.
@@ -210,33 +198,33 @@ func (world *World) updatePlayerPosition(player *Player) {
 	// if we come into contact with
 	// something, this will be changed to move to contact instead.
 
-	dy := player.Character.Speed.Y
+	dy := character.Speed.Y
 
 	// We want to be sure to lock vertical movement to a maximum of the size of the Cells within the Space
 	// so we don't miss any collisions by tunneling through.
 
 	dy = math.Max(math.Min(dy, cellSize), -cellSize)
 
-	player.Character.IsWalking = false
+	character.IsWalking = false
 
 	// We check for any solid / stand-able objects. In actuality, there aren't any other Objects
 	// with other tags in this Space, so we don't -have- to specify any tags, but it's good to be specific for clarity in this example.
-	if collision := player.Character.Object.Check(0, dy, solidTag); collision != nil {
+	if collision := character.Object.Check(0, dy, solidTag); collision != nil {
 		log.Println("Colision en y")
 
 		dy = collision.ContactWithCell(collision.Cells[0]).Y
 
-		player.Character.IsWalking = true
+		character.IsWalking = true
 	}
 
 	// Move the object on dy.
-	player.Character.Object.Position.Y += dy
+	character.Object.Position.Y += dy
 
-	player.Character.Object.Update() // Update the player's position in the space.
+	character.Object.Update() // Update the character's position in the space.
 }
 
 // UpdateCameraLimitPosition updates the position of the camera limit that is used in the world
-// to detect is a player is fully outside the camera
+// to detect is a character is fully outside the camera
 func (world *World) UpdateCameraLimitPosition(x int) {
 	world.cameraLimit.Position.X = toCameraLimitX(x)
 
@@ -244,7 +232,7 @@ func (world *World) UpdateCameraLimitPosition(x int) {
 }
 
 // toCameraLimitX transforms the position x where the camera finished to the position the camera limit object must have
-// in order to allow the camera limit to have cameraLimitWidth and to the player not collide with it until is fully outside the camera
+// in order to allow the camera limit to have cameraLimitWidth and to the character not collide with it until is fully outside the camera
 func toCameraLimitX(cameraX int) float64 {
-	return float64(cameraX - cameraLimitWidth - playerWidth)
+	return float64(cameraX - cameraLimitWidth - characterWidth)
 }


### PR DESCRIPTION
closes #61 #56 

- Cuando hay mas de un jugador en la partida, adaptar la posicion inicial de cada personaje para que no inicien todos en la misma posicion
- Una vez comenzada la partida, no aceptar nuevas conexiones
- Agregar a cada jugador un numero de jugador (id) que se envia en los mensajes "tick" e "informacionSala" para indentificar a cada jugador
- refactor: world solo maneja los characters y no los players, separando mejor las responsabilidades de cada clase

Pruebas locales:

En cliente parece no estar manejando aun la posicion de multiples jugadores en ninguno de los dos mensajes ("tick" e "informacionSala") pero se verifica en la consola que los mensajes enviados sean los correctos:

En informacionSala:
![Screenshot 2024-11-03 at 12 53 30 PM](https://github.com/user-attachments/assets/1a67ba81-eb9e-4dfa-96c4-935ed3b2cce6)

En tick:
![Screenshot 2024-11-03 at 12 54 13 PM](https://github.com/user-attachments/assets/56cdf27a-88fd-4cdf-8733-47ad8dfcb505)

Aclaracion: los ids de los jugadores son 2 y 3 y no 1 y 2 porque primero se conectó un jugador que luego se desconectó y el id de los jugadores es incremental
