### PR TITLE
62 cambiar estamuerto por estado

### DIFF
--- a/cliente/src/modelo/client_socketio.ts
+++ b/cliente/src/modelo/client_socketio.ts
@@ -18,7 +18,7 @@ export interface PosicionJugador {
     y: number,
     tieneGravedadInvertida: boolean,
     estaCaminando: boolean,
-    estaMuerto: boolean,
+    estado: string,
 }
 
 export interface ClientToServerEvents {
@@ -123,7 +123,7 @@ export class Client {
             });
 
 
-            
+
             socket.on("informacionSala", (salaID, mapa, listaJugadores) => {
                 console.log("informacionSala received", salaID, mapa, listaJugadores);
 

--- a/server/character.go
+++ b/server/character.go
@@ -11,6 +11,7 @@ type Character struct {
 	HasGravityInverted bool
 	IsWalking          bool
 	IsDead             bool
+	HasFinished        bool
 }
 
 func NewCharacter(object *resolv.Object) *Character {

--- a/server/game.go
+++ b/server/game.go
@@ -14,6 +14,14 @@ const (
 	characterSpeedY         float64 = float64(90) / ticksPerSecond
 )
 
+type PlayerStatus string
+
+const (
+	PlayerStatusOK       PlayerStatus = "ok"
+	PlayerStatusDead     PlayerStatus = "muerto"
+	PlayerStatusFinished PlayerStatus = "cruzoMeta"
+)
+
 type PlayerInfo struct {
 	playerNumber       int
 	posX               int
@@ -21,16 +29,25 @@ type PlayerInfo struct {
 	hasGravityInverted bool
 	isWalking          bool
 	isDead             bool
+	hasFinished        bool
 }
 
 func (playerInfo PlayerInfo) ToMap() map[string]any {
+	status := PlayerStatusOK
+
+	if playerInfo.isDead {
+		status = PlayerStatusDead
+	} else if playerInfo.hasFinished {
+		status = PlayerStatusFinished
+	}
+
 	return map[string]any{
 		"numeroJugador":          playerInfo.playerNumber,
 		"x":                      playerInfo.posX,
 		"y":                      playerInfo.posY,
 		"tieneGravedadInvertida": playerInfo.hasGravityInverted,
 		"estaCaminando":          playerInfo.isWalking,
-		"estaMuerto":             playerInfo.isDead,
+		"estado":                 status,
 	}
 }
 
@@ -101,6 +118,7 @@ func gameLoop(world *World, room *Room) {
 					hasGravityInverted := player.Character.HasGravityInverted
 					isWalking := player.Character.IsWalking
 					isDead := player.Character.IsDead
+					hasFinished := player.Character.HasFinished
 
 					point := Point{
 						X: int(posX),
@@ -114,6 +132,7 @@ func gameLoop(world *World, room *Room) {
 						hasGravityInverted: hasGravityInverted,
 						isWalking:          isWalking,
 						isDead:             isDead,
+						hasFinished:        hasFinished,
 					})
 				}
 

--- a/server/world.go
+++ b/server/world.go
@@ -124,7 +124,7 @@ func (world *World) Init(gameMap Map, players []*Player) {
 //   - finished: true if the character finished the race this tick
 //   - died: true if the character died this tick
 func (world *World) Update(character *Character) (bool, bool) {
-	if !character.IsDead {
+	if !character.IsDead && !character.HasFinished {
 		world.updateCharacterPosition(character)
 
 		if world.checkIfCharacterFinishedRace(character) {
@@ -155,7 +155,7 @@ func (world *World) checkIfCharacterFinishedRace(character *Character) bool {
 	if collision := character.Object.Check(0, 0, raceFinishTag); collision != nil {
 		log.Println("Character finished race")
 
-		character.IsDead = true
+		character.HasFinished = true
 
 		return true
 	}


### PR DESCRIPTION
closes #62 

- Cambiar "estaMuerto" por "estado" en el mensaje "tick" para poder diferenciar personajes que estan muertos de los que terminaron la carrera
- Agregar a los personajes nueva propiedad HasFinished para guardar la informacion de que ya terminó la carrera