### PR TITLE
remover canal gameStart ya no necesario

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -9,7 +9,7 @@ import (
 
 var rooms = map[uuid.UUID]*Room{}
 
-func manageClientConnection(clients []any, gameStart chan *Room) {
+func manageClientConnection(clients []any) {
 	newClient := clients[0].(*socket.Socket)
 	newClientID := newClient.Id()
 
@@ -59,8 +59,6 @@ func manageClientConnection(clients []any, gameStart chan *Room) {
 
 			return
 		}
-
-		gameStart <- newPlayer.Room
 	})
 	if err != nil {
 		log.Println("failed to register on iniciarJuego message", "err", err)

--- a/server/main.go
+++ b/server/main.go
@@ -16,10 +16,8 @@ func main() {
 	io := socket.NewServer(nil, nil)
 	http.Handle("/socket.io/", io.ServeHandler(nil))
 
-	gameStart := make(chan *Room)
-
 	err := io.On("connection", func(clients ...any) {
-		manageClientConnection(clients, gameStart)
+		manageClientConnection(clients)
 	})
 	if err != nil {
 		log.Fatalln("Error setting socket.io on connection", "err", err)


### PR DESCRIPTION
Hotfix para cambio que debio ser hecho en https://github.com/luchowaldman/elpibegravedad/pull/98, el canal gameStart ya no se utiliza con el nuevo esquema de salas en paralelo