### PR TITLE
100 - bug deja de mandar al recibir iniciarjuego en un juego iniciado

### DIFF
--- a/server/room.go
+++ b/server/room.go
@@ -63,12 +63,11 @@ func (room *Room) RemovePlayer(oldPlayer *Player) int {
 }
 
 func (room *Room) StartGame() bool {
-	room.Mutex.Lock()
-
 	if room.GameStarted.Load() {
 		return false
 	}
 
+	room.Mutex.Lock()
 	room.GameStarted.Store(true)
 
 	for _, player := range room.Players {


### PR DESCRIPTION
closes #100 

- Se corrije uso de lo en la funcion StartGame del room para evitar que se quede bloqueado al recibir este mensaje si la partida ya comenzó

Evidencias:
<img width="1008" alt="Screenshot 2024-11-24 at 7 55 15 PM" src="https://github.com/user-attachments/assets/6e3dd5c9-052d-40f2-a81a-8c8a14b2da48">
Ahora todas las veces que se envia ese mensaje se detecta correctamente que la partida ya comenzo y la misma puede continuar