### PR TITLE
89 - obstaculos mortales

### DIFF
--- a/server/map.go
+++ b/server/map.go
@@ -12,14 +12,16 @@ const (
 )
 
 type Map struct {
-	Height       int
-	Width        int          `json:"largo"`
-	Platforms    []Platform   `json:"plataformas"`
-	Obstacles    []Obstacle   `json:"obstaculos"`
-	PlayersStart PlayersStart `json:"inicio_jugadores"`
-	RaceFinish   RaceFinish   `json:"meta"`
+	Height         int
+	Width          int          `json:"largo"`
+	Platforms      []Platform   `json:"plataformas"`
+	Obstacles      []Obstacle   `json:"obstaculos"`
+	FatalObstacles []Obstacle   `json:"obstaculos_mortales"`
+	PlayersStart   PlayersStart `json:"inicio_jugadores"`
+	RaceFinish     RaceFinish   `json:"meta"`
 
 	Solids []Solid
+	Fatal  []Solid
 }
 
 type Solid struct {
@@ -87,7 +89,21 @@ func loadMap(name string) Map {
 		})
 	}
 
-	for _, obstacle := range gameMap.Obstacles {
+	solids = append(solids, obstaclesToSolids(gameMap.Obstacles)...)
+
+	gameMap.Solids = solids
+	gameMap.Fatal = obstaclesToSolids(gameMap.FatalObstacles)
+
+	log.Println("Map solids generated", gameMap.Solids)
+	log.Println("Map fatal generated", gameMap.Fatal)
+
+	return gameMap
+}
+
+func obstaclesToSolids(obstacles []Obstacle) []Solid {
+	solids := make([]Solid, 0, len(obstacles))
+
+	for _, obstacle := range obstacles {
 		solids = append(solids, Solid{
 			coordinates: Coordinates{
 				From: Point{
@@ -102,9 +118,5 @@ func loadMap(name string) Map {
 		})
 	}
 
-	gameMap.Solids = solids
-
-	log.Println("Map solids generated", gameMap.Solids)
-
-	return gameMap
+	return solids
 }

--- a/server/world.go
+++ b/server/world.go
@@ -20,7 +20,10 @@ const (
 	characterInitialPositionDistance = 20
 )
 
-var collisionTags = []string{solidTag, characterTag}
+var (
+	collisionTags = []string{solidTag, characterTag}
+	deadTags      = []string{worldLimitTag, fatalTag}
+)
 
 type World struct {
 	space *resolv.Space
@@ -144,7 +147,7 @@ func (world *World) Update(character *Character) (bool, bool) {
 
 // checkIfCharacterHasDied updates character's IsDead if the character touched a world limit
 func (world *World) checkIfCharacterHasDied(character *Character) bool {
-	if collision := character.Object.Check(0, 0, worldLimitTag); collision != nil {
+	if collision := character.Object.Check(0, 0, deadTags...); collision != nil {
 		log.Println("Character is dead")
 
 		character.IsDead = true

--- a/server/world.go
+++ b/server/world.go
@@ -9,6 +9,7 @@ import (
 const (
 	cellSize                         = 10
 	solidTag                         = "solid"
+	fatalTag                         = "fatal"
 	worldLimitTag                    = "worldLimit"
 	raceFinishTag                    = "raceFinish"
 	characterTag                     = "character"
@@ -81,18 +82,8 @@ func (world *World) Init(gameMap Map, players []*Player) {
 	world.space.Add(world.RaceFinish)
 
 	// Add solids
-	for _, solid := range gameMap.Solids {
-		x, y, w, h := solid.coordinates.ToDimensions()
-
-		log.Println("Adding solid: ", x, y, w, h)
-
-		world.space.Add(
-			resolv.NewObject(
-				x, y, w, h,
-				solidTag,
-			),
-		)
-	}
+	world.addSolids(gameMap.Solids, solidTag)
+	world.addSolids(gameMap.Fatal, fatalTag)
 
 	// Create Characters' objects and add it to the world's Space.
 	characterInitialX := float64(gameMap.PlayersStart.X)
@@ -114,6 +105,21 @@ func (world *World) Init(gameMap Map, players []*Player) {
 			characterInitialX = characterInitialX - characterWidth - characterInitialPositionDistance
 			characterInitialY = characterInitialY - characterHeight - characterInitialPositionDistance
 		}
+	}
+}
+
+func (world *World) addSolids(solids []Solid, tag string) {
+	for _, solid := range solids {
+		x, y, w, h := solid.coordinates.ToDimensions()
+
+		log.Println("Adding solid: ", x, y, w, h)
+
+		world.space.Add(
+			resolv.NewObject(
+				x, y, w, h,
+				tag,
+			),
+		)
 	}
 }
 


### PR DESCRIPTION
closes #89

- Leer del mapa json la lista obstaculos_mortales y poner dentro del objeto mapa
- Agregar al mundo los solidos correspondientes a los obstaculos mortales
- Agregar estos obtaculos a los solidos con los que el personaje muere al entrar en contacto

Evidencias:

![Screenshot 2024-11-24 at 9 47 58 PM](https://github.com/user-attachments/assets/e531d36a-eede-4b9a-acfd-410ef626f023)
(en este caso como es un solo jugador, en lugar de aparecer como muerto directamente termina la carrera, pero demuestra que al entrar en contacto se detecta su muerte)