### PR TITLE
86 - Mandar lista de nombres al terminar la partida

### DIFF
--- a/cliente/src/aplicacion.ts
+++ b/cliente/src/aplicacion.ts
@@ -31,7 +31,7 @@ export class Aplicacion {
     private mapa: Mapa;
     private graficos: graficoJuego;
     private nombreususario: string;
-    
+
     constructor(urlserver: string, nombreususario: string) {
         this.nombreususario = nombreususario;
         this.controladorDOM = new ControladorDOM();
@@ -80,7 +80,7 @@ export class Aplicacion {
         this.graficos.AddAnimacionEntidadGrafica('animacionmuriendo', 'player_muriendo', 0, 1, 7, -1);
         this.graficos.AddAnimacion('player_festejando', 35, 50);
         this.graficos.AddAnimacionEntidadGrafica('animacionfestejando', 'player_festejando', 0, 1, 7, -1);
-        
+
 
 
         this.graficos.agenda.agregarAccionGrafica(0, new AccionGraficaMostrarTexto(this.graficos, "status_label", "DOM INICIADO", 600, posYLabelStatus));
@@ -156,10 +156,9 @@ export class Aplicacion {
     }
 
 
-    private handleTerminoCarrera(resultado: number[]) {
+    private handleTerminoCarrera(resultado: InformacionJugador[]) {
         this.CentrarLabels();
-        this.SetLabelGrafico("Carrera Terminada", "Ganador: " + resultado[0]);
-
+        this.SetLabelGrafico("Carrera Terminada", "Ganador: " + resultado[0].nombre);
     }
 
     private handleCamara() {
@@ -198,10 +197,9 @@ export class Aplicacion {
             this.cargado = true;
 
             const url = `https://storage.googleapis.com/pibegravedadcliente/index.html`;
-            this.controladorDOM.mostrar_compartirpagina(url ,id);
+            this.controladorDOM.mostrar_compartirpagina(url, id);
             const mapaJSON = this.getMapaJSON(mapa);
-            if (mapaJSON == undefined)    
-            {
+            if (mapaJSON == undefined) {
                 console.log("Error al cargar el mapa");
                 return;
             }
@@ -211,12 +209,11 @@ export class Aplicacion {
             this.graficos.agenda.iniciar();
             this.controladorDOM.mostrar_pagina('pagina2');
         }
-        
+
         let nombrejugadores = ""
         let cont = 0;
         listaJugadores.forEach(jugador => {
-            if (cont != 0)
-            {
+            if (cont != 0) {
                 if (cont % 2 == 0)
                     nombrejugadores = nombrejugadores.concat("\n");
                 else
@@ -225,7 +222,7 @@ export class Aplicacion {
             cont++;
             nombrejugadores = nombrejugadores.concat(jugador.nombre);
         });
-        
+
         listaJugadores.map(jugador => jugador.nombre).join('\n');
 
         this.SetLabelGrafico(`En la sala, ${this.nombreususario}`, `${listaJugadores.length} Jugadores: \n ${nombrejugadores}`);

--- a/cliente/src/modelo/client_socketio.ts
+++ b/cliente/src/modelo/client_socketio.ts
@@ -3,7 +3,7 @@ import { io, Socket } from "socket.io-client";
 interface ServerToClientEvents {
     inicioJuego: () => void;
     tick: (posiciones: PosicionJugador[], camaraX: number) => void;
-    carreraTerminada: (resultado: number[]) => void;
+    carreraTerminada: (resultado: InformacionJugador[]) => void;
     informacionSala: (salaID: string, mapa: string, listaJugadores: InformacionJugador[]) => void;
 }
 
@@ -51,9 +51,9 @@ export class Client {
         this.InformacionSalaHandler = handler;
     }
 
-    private carreraTerminadaHandler?: (resultado: number[]) => void;
+    private carreraTerminadaHandler?: (resultado: InformacionJugador[]) => void;
 
-    public setCarreraTerminadaHandler(handler: (resultado: number[]) => void) {
+    public setCarreraTerminadaHandler(handler: (resultado: InformacionJugador[]) => void) {
         this.carreraTerminadaHandler = handler;
     }
 
@@ -116,7 +116,7 @@ export class Client {
             });
 
             socket.on("carreraTerminada", (resultado) => {
-                console.log("carreraTerminada received %s", resultado)
+                console.log("carreraTerminada received", resultado)
                 this.carreraTerminadaHandler?.(resultado);
             });
 

--- a/server/game.go
+++ b/server/game.go
@@ -112,12 +112,7 @@ func gameLoop(world *World, room *Room) {
 
 				raceResult := append(playersThatFinished, playersThatDied...)
 
-				for _, player := range room.Players {
-					err := player.SendCarreraTerminada(raceResult)
-					if err != nil {
-						log.Println("failed to send carreraTerminada", "err", err)
-					}
-				}
+				sendCarreraTerminada(room, raceResult)
 
 				ticker.Stop()
 				return
@@ -203,4 +198,26 @@ func calculateCameraPosition(maxPlayerPosX int) int {
 	}
 
 	return cameraX
+}
+
+func sendCarreraTerminada(room *Room, raceResult []int) {
+	playersResults := make([]map[string]any, 0, len(raceResult))
+
+	for _, playerID := range raceResult {
+		playerIndex := slices.IndexFunc(room.Players, func(player *Player) bool {
+			return player.ID == playerID
+		})
+
+		playersResults = append(
+			playersResults,
+			room.Players[playerIndex].ToInformacionSalaInfo(),
+		)
+	}
+
+	for _, player := range room.Players {
+		err := player.SendCarreraTerminada(playersResults)
+		if err != nil {
+			log.Println("failed to send carreraTerminada", "err", err)
+		}
+	}
 }

--- a/server/player.go
+++ b/server/player.go
@@ -38,7 +38,7 @@ func (player *Player) ToInformacionSalaInfo() map[string]any {
 	}
 }
 
-func (player *Player) SendCarreraTerminada(raceResult []int) error {
+func (player *Player) SendCarreraTerminada(raceResult []map[string]any) error {
 	return player.emit("carreraTerminada", raceResult)
 }
 


### PR DESCRIPTION
 # closes 86

- Enviar en el mensaje "carreraTerminada" el mapa InformacionSala del jugador que incluye numeroJugador y nombre, de manera que el cliente pueda mostrar el nombre del jugador ganador en lugar de solo su numero
- Adaptar receptor para tener en cuenta nuevo formato del mensaje

Evidencia del funcionamiento local:
![Screenshot 2024-12-07 at 7 49 56 PM](https://github.com/user-attachments/assets/7123fd43-8b75-42df-9a6d-2a78c5dd3553)
Como podemos ver, el cliente solo muestra el nombre del ganador, pero el servidor envia toda la lista en orden, queda a consideracion del cliente mostrar toda la lista o solo al ganador:
![Screenshot 2024-12-07 at 7 50 16 PM](https://github.com/user-attachments/assets/11b61594-1c89-42c2-998a-b04056bbcbc0)
