### PR TITLE
85 - fixbug personajes no colisionan mas al morir o cruzar la meta

### DIFF
--- a/server/world.go
+++ b/server/world.go
@@ -157,6 +157,7 @@ func (world *World) checkIfCharacterHasDied(character *Character) bool {
 		log.Println("Character is dead")
 
 		character.IsDead = true
+		character.Object.RemoveTags(characterTag) // remove character tag to avoid collisions
 
 		return true
 	}
@@ -170,6 +171,7 @@ func (world *World) checkIfCharacterFinishedRace(character *Character) bool {
 		log.Println("Character finished race")
 
 		character.HasFinished = true
+		character.Object.RemoveTags(characterTag) // remove character tag to avoid collisions
 
 		return true
 	}


### PR DESCRIPTION
closes #85

- Remover tag characters de los objetos que representar a los personajes en el mundo al morir o cruzar la meta, de modo que no sean tenidos en cuenta durante la deteccion de colisiones

Evidencia en local:
Como podemos ver, una vez un persanaje muere por chocar con un pinche, el personaje que viene por detras puede atravesarlo
![Screenshot 2024-12-07 at 8 02 53 PM](https://github.com/user-attachments/assets/078840b0-6fd8-488b-b59d-defbfb8bc22d)
