### PR TITLE
79 - correccion correr el momendo de muerte del personaje

### DIFF
--- a/server/world.go
+++ b/server/world.go
@@ -240,9 +240,9 @@ func (world *World) UpdateCameraLimitPosition(x int) {
 }
 
 // toCameraLimitX transforms the position x where the camera finished to the position the camera limit object must have
-// in order to allow the camera limit to have cameraLimitWidth and to the character not collide with it until is fully outside the camera
+// in order to allow the camera limit to have cameraLimitWidth
 func toCameraLimitX(cameraX int) float64 {
-	return float64(cameraX - cameraLimitWidth - characterWidth)
+	return float64(cameraX - cameraLimitWidth)
 }
 
 func setSpeedMultiplier(character *Character, collision *resolv.Collision) {


### PR DESCRIPTION
closes #79 

- Eliminar el corrimiento del objeto que representa el camara limit el ancho del personaje mas a la izquierda. De esta forma, el personaje moriría apenas haga contacto con el limite de la pantalla
